### PR TITLE
Score UI

### DIFF
--- a/scoring/converter.py
+++ b/scoring/converter.py
@@ -1,0 +1,35 @@
+from sr.comp.scorer import Converter as BaseConverter
+
+
+class Converter(BaseConverter):
+    def form_team_to_score(self, form, zone_id):
+        left_scoring_zone = form.get(f'left_scoring_zone_{zone_id}')
+        robot_tokens = form.get(f'robot_tokens_{zone_id}') or ''
+        return {
+            **super().form_team_to_score(form, zone_id),
+            'left_scoring_zone': left_scoring_zone is not None,
+            'robot_tokens': robot_tokens,
+        }
+
+    def score_to_form(self, score):
+        form = super().score_to_form(score)
+
+        for info in score['teams'].values():
+            zone_id = info['zone']
+            form[f'left_scoring_zone_{zone_id}'] = info.get(
+                'left_scoring_zone',
+                False,
+            )
+            form[f'robot_tokens_{zone_id}'] = info.get('robot_tokens', '')
+
+        return form
+
+    def match_to_form(self, match):
+        form = super().match_to_form(match)
+
+        for zone_id, tla in enumerate(match.teams):
+            if tla:
+                form[f'left_scoring_zone_{zone_id}'] = False
+                form[f'robot_tokens_{zone_id}'] = ''
+
+        return form

--- a/scoring/template.yaml
+++ b/scoring/template.yaml
@@ -1,0 +1,40 @@
+arena_id: main
+arena_zones:
+  0:
+    # Tokens which were in the zone at the end. Valid tokens are B, S & G.
+    tokens: GG
+  1:
+    tokens: ''
+  2:
+    tokens: S
+  3:
+    tokens: ''
+  other:
+    tokens: ''
+match_number: 0
+teams:
+  TLA0:
+    disqualified: false
+    left_scoring_zone: true
+    present: true
+    # Tokens which were in the robot at the end. Valid tokens are B, S & G.
+    robot_tokens: BB
+    zone: 0
+  TLA1:
+    disqualified: true
+    left_scoring_zone: false
+    present: false
+    robot_tokens: ''
+    zone: 1
+  TLA2:
+    disqualified: false
+    left_scoring_zone: false
+    present: false
+    robot_tokens: S
+    zone: 2
+  TLA3:
+    disqualified: false
+    left_scoring_zone: false
+    present: false
+    robot_tokens: ''
+    zone: 3

--- a/scoring/update.html
+++ b/scoring/update.html
@@ -1,0 +1,87 @@
+{% extends "_update.html" %}
+
+{% macro input_robot_tokens_wider(x, y, corner) %}
+<foreignObject x="{{ x }}" y="{{ y }}" width="70" height="30">
+  <label for="robot_tokens_{{ corner }}">Robot Tokens</label>
+</foreignObject>
+<foreignObject x="{{ x + 75 }}" y="{{ y }}" width="150" height="30">
+  <input
+    class="tokens"
+    type="text"
+    id="robot_tokens_{{ corner }}"
+    name="robot_tokens_{{ corner }}"
+    value="{{ request.form.get('robot_tokens_{}'.format(corner)) | empty_if_none }}"
+    onkeyup="token_input_change(this);"
+  />
+</foreignObject>
+{% endmacro %}
+
+{% macro input_zone_tokens_wider(x, y, corner) %}
+<foreignObject x="{{ x }}" y="{{ y }}" width="70" height="30">
+  <label for="tokens_{{ corner }}">Zone Tokens</label>
+</foreignObject>
+<foreignObject x="{{ x + 75 }}" y="{{ y }}" width="150" height="30">
+  <input
+    class="tokens"
+    type="text"
+    id="tokens_{{ corner }}"
+    name="tokens_{{ corner }}"
+    value="{{ request.form.get('tokens_{}'.format(corner)) | empty_if_none }}"
+    onkeyup="token_input_change(this);"
+  />
+</foreignObject>
+{% endmacro %}
+
+{% macro input_left_scoring_zone(x, y, corner) %}
+{{ input_checkbox(x,y,132,corner,"left_scoring_zone","Fully Left Zone")}}
+{% endmacro %}
+
+{% block zone_0 %}
+{{ input_tla(70, 50, 0) }}
+{{ input_zone_tokens_wider(40, 95, 0) }}
+{{ input_robot_tokens_wider(40, 130, 0) }}
+{{ input_present(70, 175, 0) }}
+{{ input_left_scoring_zone(18, 210, 0) }}
+{{ input_disqualified(30, 245, 0) }}
+{% endblock %}
+
+{% block zone_1 %}
+{{ input_tla(365, 50, 1) }}
+{{ input_zone_tokens_wider(335, 95, 1) }}
+{{ input_robot_tokens_wider(335, 130, 1) }}
+{{ input_present(445, 175, 1) }}
+{{ input_left_scoring_zone(393, 210, 1) }}
+{{ input_disqualified(405, 245, 1) }}
+{% endblock %}
+
+{% block zone_2 %}
+{{ input_tla(380, 320, 2) }}
+{{ input_zone_tokens_wider(350, 365, 2) }}
+{{ input_robot_tokens_wider(350, 400, 2) }}
+{{ input_present(405, 445, 2) }}
+{{ input_left_scoring_zone(353, 480, 2) }}
+{{ input_disqualified(365, 515, 2) }}
+{% endblock %}
+
+{% block zone_3 %}
+{{ input_tla(40, 320, 3) }}
+{{ input_zone_tokens_wider(10, 365, 3) }}
+{{ input_robot_tokens_wider(10, 400, 3) }}
+{{ input_present(105, 445, 3) }}
+{{ input_left_scoring_zone(53, 480, 3) }}
+{{ input_disqualified(65, 515, 3) }}
+{% endblock %}
+
+{% block zone_other_outline %}
+<rect height="120" width="120" stroke="#000" y="240" x="240" stroke-width="1" fill="#f4f3ff" />
+{% endblock %}
+
+{% block zone_other %}
+<foreignObject x="250" y="250" height="100" width="100">
+  <img src="{{ url_for('static', filename='images/logo.png') }}" />
+</foreignObject>
+{% endblock %}
+
+{% block valid_token_regex %}
+var valid_token_regex = /^[BSG]*$/;
+{% endblock %}

--- a/scoring/update.html
+++ b/scoring/update.html
@@ -1,10 +1,10 @@
 {% extends "_update.html" %}
 
 {% macro input_robot_tokens_wider(x, y, corner) %}
-<foreignObject x="{{ x }}" y="{{ y }}" width="70" height="30">
+<foreignObject x="{{ x }}" y="{{ y }}" width="120" height="30">
   <label for="robot_tokens_{{ corner }}">Robot Tokens</label>
 </foreignObject>
-<foreignObject x="{{ x + 75 }}" y="{{ y }}" width="150" height="30">
+<foreignObject x="{{ x + 125 }}" y="{{ y }}" width="150" height="30">
   <input
     class="tokens"
     type="text"
@@ -17,10 +17,10 @@
 {% endmacro %}
 
 {% macro input_zone_tokens_wider(x, y, corner) %}
-<foreignObject x="{{ x }}" y="{{ y }}" width="70" height="30">
+<foreignObject x="{{ x + 5 }}" y="{{ y }}" width="120" height="30">
   <label for="tokens_{{ corner }}">Zone Tokens</label>
 </foreignObject>
-<foreignObject x="{{ x + 75 }}" y="{{ y }}" width="150" height="30">
+<foreignObject x="{{ x + 125 }}" y="{{ y }}" width="150" height="30">
   <input
     class="tokens"
     type="text"
@@ -38,8 +38,8 @@
 
 {% block zone_0 %}
 {{ input_tla(70, 50, 0) }}
-{{ input_zone_tokens_wider(40, 95, 0) }}
-{{ input_robot_tokens_wider(40, 130, 0) }}
+{{ input_zone_tokens_wider(10, 95, 0) }}
+{{ input_robot_tokens_wider(10, 130, 0) }}
 {{ input_present(70, 175, 0) }}
 {{ input_left_scoring_zone(18, 210, 0) }}
 {{ input_disqualified(30, 245, 0) }}
@@ -47,8 +47,8 @@
 
 {% block zone_1 %}
 {{ input_tla(365, 50, 1) }}
-{{ input_zone_tokens_wider(335, 95, 1) }}
-{{ input_robot_tokens_wider(335, 130, 1) }}
+{{ input_zone_tokens_wider(310, 95, 1) }}
+{{ input_robot_tokens_wider(310, 130, 1) }}
 {{ input_present(445, 175, 1) }}
 {{ input_left_scoring_zone(393, 210, 1) }}
 {{ input_disqualified(405, 245, 1) }}
@@ -56,8 +56,8 @@
 
 {% block zone_2 %}
 {{ input_tla(380, 320, 2) }}
-{{ input_zone_tokens_wider(350, 365, 2) }}
-{{ input_robot_tokens_wider(350, 400, 2) }}
+{{ input_zone_tokens_wider(310, 365, 2) }}
+{{ input_robot_tokens_wider(310, 400, 2) }}
 {{ input_present(405, 445, 2) }}
 {{ input_left_scoring_zone(353, 480, 2) }}
 {{ input_disqualified(365, 515, 2) }}


### PR DESCRIPTION
This adds a score-entry UI for SR2023's game.

Once we're happy with the design, we can look at replicating it into the printable format for the paper sheets.

![image](https://user-images.githubusercontent.com/336212/218568980-377f1eb8-b322-4eaa-8937-188e5b52bc94.png)

Valid tokens are `B`, `S` & `G`.

Fixes https://github.com/srobo/tasks/issues/1107 
Fixes https://github.com/srobo/tasks/issues/1039
